### PR TITLE
<s> strikeout tag doesn't ruin parser state

### DIFF
--- a/src/html/parser.d
+++ b/src/html/parser.d
@@ -267,6 +267,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreStyle_ST;
 			} else {
 				state = TagName;
+				goto case TagName;
 			}
 			break;
 
@@ -308,6 +309,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingStyle_ST;
 			} else {
 				state = Text;
+				goto case Text;
 			}
 			break;
 
@@ -754,7 +756,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreScript_SCR;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -763,7 +765,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreScript_SCRI;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -772,7 +774,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreScript_SCRIP;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -781,7 +783,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreScript_SCRIPT;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -790,14 +792,14 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				textState = ParserTextStates.Script;
 
 			state = TagName;
-			continue;
+			goto case TagName;
 
 		case PreStyle_ST:
 			if ((*ptr == 'y') || (*ptr == 'Y')) {
 				state = PreStyle_STY;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -806,7 +808,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreStyle_STYL;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -815,7 +817,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = PreStyle_STYLE;
 			} else {
 				state = TagName;
-				continue;
+				goto case TagName;
 			}
 			break;
 
@@ -824,14 +826,14 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				textState = ParserTextStates.Style;
 
 			state = TagName;
-			continue;
+			goto case TagName;
 
 		case ClosingScript_SC:
 			if ((*ptr == 'r') || (*ptr == 'R')) {
 				state = ClosingScript_SCR;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -840,7 +842,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingScript_SCRI;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -849,7 +851,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingScript_SCRIP;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -858,7 +860,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingScript_SCRIPT;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -870,6 +872,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				continue;
 			} else {
 				state = Text;
+				goto case Text;
 			}
 			break;
 
@@ -877,8 +880,8 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 			if ((*ptr == 'y') || (*ptr == 'Y')) {
 				state = ClosingStyle_STY;
 			} else {
-				state = TagName;
-				continue;
+				state = Text;
+				goto case Text;
 			}
 			break;
 
@@ -887,7 +890,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingStyle_STYL;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -896,7 +899,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				state = ClosingStyle_STYLE;
 			} else {
 				state = Text;
-				continue;
+				goto case Text;
 			}
 			break;
 
@@ -908,6 +911,7 @@ void parseHTML(Handler, size_t options = ParserOptions.Default)(const(char)[] so
 				continue;
 			} else {
 				state = Text;
+				goto case Text;
 			}
 			break;
 		}


### PR DESCRIPTION
It was checking if it's a <style> tag and if not, going into TagName state and breaking out of the switch, which incremented the position (++pos). For <s>, that meant it went from 's' to '>' and assumed '>' was part of the tag name, then searched forward through the contents of the <s> tag for a whitespace or '>' character, continuing to build the tag name.

Also took the liberty of making the state machine a bit clearer, using the goto case statement. Unlike using continue, that skips the redundant check of what the state variable is. (i.e. continue = check to see that state is TagName, jump to state TagName, goto case TagName = just jump to state TagName). It might not even be necessary to say "state = TagName" in the goto case situations, but that's a bit squirrelier, so I left the state variable consistent.

Also found a few bugs, such as a </sty> tag switching to state TagName, not state Text! A few other places where it wasn't continuing, which makes ++pos skip over another character it should have rechecked. I might have been a bit too zealous there... works fine AFAICT, but there's some warnings about "unreachable code" now (i.e. less work for the computer yay, but shaky logic boo)
