### PR TITLE
Automatically self-close <wbr> tags

### DIFF
--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -880,6 +880,7 @@ struct DOMBuilder(Document) {
 		case tagHashOf("link"):
 		case tagHashOf("meta"):
 		case tagHashOf("param"):
+		case tagHashOf("wbr"):
 			onSelfClosing();
 			break;
 		default:


### PR DESCRIPTION
The presence of non-explicitly closed <wbr> tags was causing the DOM to break. This fixes it by adding them to the list of self-closing tags.
