### PR TITLE
Node cloning across documents

### DIFF
--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -774,6 +774,19 @@ struct Node {
 		return type == NodeTypes.ProcessingInstruction;
 	}
 
+	Node* clone(Document* newdocument, PageAllocator!(Node, 1024) alloc) {
+		Node* c = alloc.alloc();
+		*c = Node(newdocument, tag_);
+		c.flags_ = flags_;
+		Node* cur = firstChild_;
+		while(cur != null) {
+			Node* newChild = cur.clone(newdocument, alloc);
+			c.appendChild(newChild);
+			cur = cur.next_;
+		}
+		return c;
+	}
+
 package:
 	enum TypeMask	= 0x7;
 	enum TypeShift	= 0;
@@ -796,7 +809,6 @@ package:
 
 	Document* document_;
 }
-
 
 auto createDocument(size_t options = DOMCreateOptions.Default)(HTMLString source) {
 	enum parserOptions = ((options & DOMCreateOptions.DecodeEntities) ? ParserOptions.DecodeEntities : 0);
@@ -867,6 +879,10 @@ static auto createDocument() {
 
 
 struct Document {
+	auto clone(Node* source) {
+		return source.clone(&this, alloc_);
+	}
+
 	auto createElement(HTMLString tagName, Node* parent = null) {
 		auto node = alloc_.alloc();
 		*node = Node(&this, tagName);
@@ -1032,6 +1048,24 @@ private:
 	Node* root_;
 	PageAllocator!(Node, 1024) alloc_;
 }
+
+///
+unittest {
+	//import htmld: createDocument;
+	const(char)[] s = "<parent><child/>andsometext</parent>";
+	auto doc = createDocument(s);
+	s = doc.root().html();
+	auto c = doc.clone(doc.root());
+	assert(s == c.html);
+	assert(s == doc.root().html());
+	auto other = createDocument();
+	c = other.clone(doc.root());
+	assert(s == c.html);
+	other.root().appendChild(c);
+	s = "<root>"~s~"</root>";
+	assert(s == other.root().html());
+}
+
 
 
 struct DOMBuilder(Document) {

--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -778,6 +778,10 @@ struct Node {
 		Node* c = alloc.alloc();
 		*c = Node(newdocument, tag_);
 		c.flags_ = flags_;
+		foreach(HTMLString attr, HTMLString value; attrs_) {
+			c.attrs_[attr] = value;
+		}
+
 		Node* cur = firstChild_;
 		while(cur != null) {
 			Node* newChild = cur.clone(newdocument, alloc);
@@ -1052,18 +1056,24 @@ private:
 ///
 unittest {
 	//import htmld: createDocument;
-	const(char)[] s = "<parent><child/>andsometext</parent>";
+	const(char)[] s = `<parent attr="value"><child/>andsometext</parent>`;
 	auto doc = createDocument(s);
-	s = doc.root().html();
+	s = doc.root().html(); // normalize
 	auto c = doc.clone(doc.root());
 	assert(s == c.html);
 	assert(s == doc.root().html());
 	auto other = createDocument();
-	c = other.clone(doc.root());
-	assert(s == c.html);
-	other.root().appendChild(c);
+	c = other.clone(doc.root().children.front);
+	assert(s == c.outerHTML);
+	
+	s = `<parent attr="value"><child></child>andsometext<parent attr="value"><child></child>andsometext</parent></parent>`;
+	c.appendChild(other.clone(c));
+	assert(s == c.outerHTML);
+
 	s = "<root>"~s~"</root>";
-	assert(s == other.root().html());
+	other.root().appendChild(c);
+
+	assert(s == other.root().outerHTML());
 }
 
 


### PR DESCRIPTION
A way to copy a node, without having to serialize it to a string. The document that does the cloning becomes the new node's document.
