### PR TITLE
Removing tree inconsistencies

### DIFF
--- a/detach-link-notes.md
+++ b/detach-link-notes.md
@@ -1,0 +1,54 @@
+* D E F
+* A B C
+
+`E.insertAfter(B) ->`
+
+* D F
+* A B E C
+
+* B
+  * _next_ = C
+  * prev = A
+
+* C
+ * next = null
+ * _prev_ = B
+
+* E
+ * _next_ = F
+ * _prev_ = D
+ * _parent_ = ???
+
+* D
+ * _next_ = E
+ * _prev_ = F
+
+* F
+  * next = null
+  * _prev_ = E
+
+italic properties must change.
+
+```D
+// first, fix old nodes.
+if(E == E.parent.firstChild) // nope
+  // E.prev must be null if this is true, short circuit logic?
+  E.parent.firstChild = E.next;
+if(E == E.parent.lastChild) // nope
+  // E.next must be null if this is true, short circuit logic?
+  E.parent.lastChild = E.prev;
+if(E.next) // F
+  E.next.prev = E.prev;
+if(E.prev) // D
+  E.prev.next = E.next;
+// insertBefore is an exact mirror of this beyond this point, and identical before.
+// the links on E are free to scram now
+E.prev = B;
+E.next = B.next;
+
+// now, set links to E
+
+if(B.next) // C
+  B.next.prev = E;
+B.next = E;
+```

--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -325,7 +325,9 @@ struct Node {
 			assert(!lastChild_);
 			firstChild_ = node;
 			lastChild_ = node;
+			lastChild_.next_ = null;
 		}
+		firstChild_.prev_ = null;
 	}
 
 	void appendChild(Node* node) {
@@ -343,8 +345,10 @@ struct Node {
 		} else {
 			assert(!firstChild_);
 			firstChild_ = node;
+			firstChild_.prev_ = null;
 			lastChild_ = node;
 		}
+		lastChild_.next_ = null;
 	}
 
 	void removeChild(Node* node) {
@@ -391,19 +395,25 @@ struct Node {
 			firstChild_ = node;
 			lastChild_ = node;
 		}
+		lastChild_.next_ = null;
 		node.parent_ = &this;
 	}
 
 	void insertBefore(Node* node) {
 		assert(document_ == node.document_);
-
+		assert(node);
+		
 		parent_ = node.parent_;
 		prev_ = node.prev_;
 		next_ = node;
 		node.prev_ = &this;
 
-		if (parent_ && (parent_.firstChild_ == node))
-			parent_.firstChild_ = &this;
+		if (parent_ && (parent_.firstChild_ == node)) {
+		  assert(!prev_);
+		  parent_.firstChild_ = &this;
+		} else if(prev_) {
+		  prev_.next_ = &this;
+		}
 	}
 
 	void insertAfter(Node* node) {
@@ -413,6 +423,12 @@ struct Node {
 		prev_ = node;
 		next_ = node.next_;
 		node.next_ = &this;
+		if(parent_ && (parent_.lastChild_ == node)) {
+		  assert(!next_);
+		  parent_.lastChild_ = &this;
+		} else if(next_) {
+		  next_.prev_ = &this;
+		}
 	}
 
 	void detach() {
@@ -444,7 +460,16 @@ struct Node {
 				prev_ = null;
 			}
 			parent_ = null;
+		} else {
+		  if(prev_) {
+			prev_.next_ = next_;
+		  }
+		  if(next_) {
+			next_.prev_ = prev_;
+		  }
 		}
+		prev_ = null;
+		next_ = null;
 	}
 
 	package void detachFast() {
@@ -471,7 +496,16 @@ struct Node {
 					next_.prev_ = prev_;
 				}
 			}
+		} else {
+		  if(prev_) {
+			prev_.next_ = next_;
+		  }
+		  if(next_) {
+			next_.prev_ = prev_;
+		  }
 		}
+		prev_ = null;
+		next_ = null;
 	}
 
 	void destroy() {


### PR DESCRIPTION
Leftover bad links to detached/moved nodes. A few times I think a link back was needed, to remove it from the list. Some last/first child nodes not getting updated.
