### PR TITLE
Escaping and quoting issues

### DIFF
--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -601,14 +601,9 @@ class Node {
 				app.put(attr);
 
 				if (value.length) {
-					if (value.requiresQuotes) {
-						app.put("=\"");
-						app.writeQuotesEscaped(value);
-						app.put("\"");
-					} else {
-						app.put('=');
-						app.put(value);
-					}
+					app.put("=\"");
+					app.writeQuotesEscaped(value);
+					app.put("\"");
 				}
 			}
 
@@ -669,14 +664,9 @@ class Node {
 				app.put(attr);
 
 				if (value.length) {
-					if (value.requiresQuotes) {
-						app.put("=\"");
-						app.writeQuotesEscaped(value);
-						app.put("\"");
-					} else {
-						app.put('=');
-						app.put(value);
-					}
+					app.put("=\"");
+					app.writeQuotesEscaped(value);
+					app.put("\"");
 				}
 			}
 
@@ -1127,6 +1117,12 @@ unittest {
 	assert(doc.root.outerHTML == `<root><br><div></div></root>`, doc.root.outerHTML);
 }
 
+// quotes should be preserved as they are mandatory in SVG
+unittest {
+	auto doc = createDocument(`<svg><text x="7" /></svg>`);
+	assert(doc.root.outerHTML == `<root><svg><text x="7"></text></svg></root>`, doc.root.outerHTML);
+}
+
 // toString prints elements with content as <tag attr="value"/>
 unittest {
 	// self-closed element w/o content
@@ -1346,8 +1342,8 @@ private:
 
 
 unittest {
-	const(char)[] src = `<parent attr=value><child></child>text</parent>`;
-	auto doc = createDocument(src);
+	const(char)[] src = `<parent attr="value"><child></child>text</parent>`;
+	auto doc = createDocument(`<parent attr=value><child></child>text</parent>`);
 	assert(doc.root.html == src, doc.root.html);
 
 	const(char)[] srcq = `<parent attr="v a l u e"><child></child>text</parent>`;
@@ -1366,11 +1362,11 @@ unittest {
 	auto child = cloned.find("child").front.clone;
 	child.attr("attr", "test");
 	cloned.find("parent").front.appendChild(child);
-	assert(cloned.html == `<parent attr=value><child></child>text<child attr=test></child></parent>`, cloned.html);
+	assert(cloned.html == `<parent attr="value"><child></child>text<child attr="test"></child></parent>`, cloned.html);
 	assert(doc.root.html == src, doc.root.html);
 
 	child.text = "text";
-	assert(cloned.html == `<parent attr=value><child></child>text<child attr=test>text</child></parent>`, cloned.html);
+	assert(cloned.html == `<parent attr="value"><child></child>text<child attr="test">text</child></parent>`, cloned.html);
 	assert(doc.root.html == src, doc.root.html);
 
 	// document cloning

--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -602,7 +602,7 @@ class Node {
 
 				if (value.length) {
 					app.put("=\"");
-					app.writeQuotesEscaped(value);
+					app.writeHTMLEscaped!(Yes.escapeQuotes)(value);
 					app.put("\"");
 				}
 			}
@@ -628,7 +628,7 @@ class Node {
 			}
 			break;
 		case Text:
-			app.put(tag_);
+			app.writeHTMLEscaped!(No.escapeQuotes)(tag_);
 			break;
 		case Comment:
 			app.put("<!--");
@@ -665,7 +665,7 @@ class Node {
 
 				if (value.length) {
 					app.put("=\"");
-					app.writeQuotesEscaped(value);
+					app.writeHTMLEscaped!(Yes.escapeQuotes)(value);
 					app.put("\"");
 				}
 			}
@@ -758,7 +758,7 @@ class Node {
 					} else {
 						space = false;
 					}
-					app.put(ch);
+					app.writeHTMLEscaped!(No.escapeQuotes)(ch);
 				}
 			}
 			break;
@@ -1095,11 +1095,22 @@ unittest {
 	auto doc = createDocument(`<html><body>&nbsp;</body></html>`);
 	assert(doc.root.outerHTML == "<root><html><body>\&nbsp;</body></html></root>");
 	doc = createDocument!(DOMCreateOptions.None)(`<html><body>&nbsp;</body></html>`);
-	assert(doc.root.outerHTML == `<root><html><body>&nbsp;</body></html></root>`);
+	assert(doc.root.outerHTML == `<root><html><body>&amp;nbsp;</body></html></root>`);
 	doc = createDocument(`<script>&nbsp;</script>`);
 	assert(doc.root.outerHTML == `<root><script>&nbsp;</script></root>`, doc.root.outerHTML);
 	doc = createDocument(`<style>&nbsp;</style>`);
 	assert(doc.root.outerHTML == `<root><style>&nbsp;</style></root>`, doc.root.outerHTML);
+}
+
+unittest {
+	string src = `&lt;script&gt;alert("test&amp;");&lt;/script&gt;`;
+	auto doc = createDocument(src);
+	assert(doc.root.html == src, doc.root.html);
+	assert(doc.root.compactHTML == src, doc.root.compactHTML);
+	src = `<div title="&gt;&lt;script&gt;alert('test&amp;');&lt;/script&gt;"></div>`;
+	doc = createDocument(src);
+	assert(doc.root.html == src, doc.root.html);
+	assert(doc.root.compactHTML == src, doc.root.compactHTML);
 }
 
 unittest {

--- a/src/html/utils.d
+++ b/src/html/utils.d
@@ -57,42 +57,32 @@ hash_t tagHashOf(const(char)[] x) {
 }
 
 
-void writeQuotesEscaped(Appender)(ref Appender app, const(char)[] x) {
-	foreach (dchar ch; x) {
-		switch (ch) {
+void writeHTMLEscaped(Flag!q{escapeQuotes} escapeQuotes, Appender)(ref Appender app, dchar ch) {
+	switch (ch) {
+		static if (escapeQuotes) {
 			case '"':
 				app.put("&#34;"); // shorter than &quot;
 				static assert('"' == 34);
 				break;
-			default:
-				app.put(ch);
-				break;
 		}
+		case '<':
+			app.put("&lt;");
+			break;
+		case '>':
+			app.put("&gt;");
+			break;
+		case '&':
+			app.put("&amp;");
+			break;
+		default:
+			app.put(ch);
+			break;
 	}
 }
 
 
 void writeHTMLEscaped(Flag!q{escapeQuotes} escapeQuotes, Appender)(ref Appender app, const(char)[] x) {
 	foreach (dchar ch; x) {
-		switch (ch) {
-			static if (escapeQuotes) {
-				case '"':
-					app.put("&#34;"); // shorter than &quot;
-					static assert('"' == 34);
-					break;
-			}
-			case '<':
-				app.put("&lt;");
-				break;
-			case '>':
-				app.put("&gt;");
-				break;
-			case '&':
-				app.put("&amp;");
-				break;
-			default:
-				app.put(ch);
-				break;
-		}
+		writeHTMLEscaped!escapeQuotes(app, ch);
 	}
 }

--- a/src/html/utils.d
+++ b/src/html/utils.d
@@ -17,28 +17,6 @@ bool isAllWhite(Char)(Char[] value) {
 }
 
 
-bool requiresQuotes(Char)(Char[] value) {
-	auto ptr = value.ptr;
-	const end = ptr + value.length;
-
-	while (ptr != end) {
-		switch (*ptr++) {
-		case 'a': .. case 'z':
-		case 'A': .. case 'Z':
-		case '0': .. case '9':
-		case '-':
-		case '_':
-		case '.':
-		case ':':
-			continue;
-		default:
-			return true;
-		}
-	}
-	return false;
-}
-
-
 bool equalsCI(CharA, CharB)(const(CharA)[] a, const(CharB)[] b) {
 	if (a.length == b.length) {
 		for (size_t i; i < a.length; ++i) {


### PR DESCRIPTION
1. Quotation marks are mandatory in XML. Since there is no easy way of telling HTML apart from HTML-looking XML (`<title>` is both an HTML and SVG tag, for example), we should quote everything.
This also addresses #31.

2. Some entities must be preserved to prevent JS injection attacks:
```d
// Read properly escaped text.
auto doc = createDocument(`&lt;script&gt;alert("Hello!");&lt;/script&gt;`);
// Write malicious code.
assert(doc.root.innerHTML == `<script>alert("Hello!");</script>`);
```