### PR TITLE
Make `Node.opIndexAssign` more consistent with `attr`

### DIFF
--- a/src/html/dom.d
+++ b/src/html/dom.d
@@ -274,6 +274,10 @@ class Node {
 		return attr(name);
 	}
 
+	void opIndexAssign(HTMLString value, HTMLString name) {
+		attr(name, value);
+	}
+
 	void opIndexAssign(T)(T value, HTMLString name) {
 		attr(name, value.to!string);
 	}


### PR DESCRIPTION
`node["key"] = s;` allocates a copy of `s` while `node.attr("key", s);` does not. I'd prefer the later behaviour since a user might want to maintain his own buffer instead of heap-allocating a huge number of tiny strings.

Note: this is a breaking change.